### PR TITLE
allow -useprevious flag which merges any parameters in the existing

### DIFF
--- a/boondoggle/cli.py
+++ b/boondoggle/cli.py
@@ -43,7 +43,7 @@ def cli(context, profile, region):
 @click.option('--outputs-from',
               help="Use another stack's outputs as inputs to this one.")
 @click.option('--use-previous-params', is_flag=True,
-              help="Use existing stack's parameters if any are excluded from this call.")
+              help="Default any excluded parameters to their existing values in Cloud Formation")
 def ensure(context, name, params, url, file, outputs_from, use_previous_params):
     """Updates the stack with the given name to use
     the specified template. This creates the stack if

--- a/boondoggle/cli.py
+++ b/boondoggle/cli.py
@@ -42,7 +42,9 @@ def cli(context, profile, region):
               help="Path to a cloudformation file.")
 @click.option('--outputs-from',
               help="Use another stack's outputs as inputs to this one.")
-def ensure(context, name, params, url, file, outputs_from):
+@click.option('--useprevious',
+              help="Use existing stack's parameters if any are excluded from this call.")
+def ensure(context, name, params, url, file, outputs_from, useprevious):
     """Updates the stack with the given name to use
     the specified template. This creates the stack if
     necessary.
@@ -55,7 +57,8 @@ def ensure(context, name, params, url, file, outputs_from):
             template_parameters.append((k, v))
     context.obj.ensure(name, template_parameters,
                        url=url, path=file,
-                       outputs_from=outputs_from)
+                       outputs_from=outputs_from,
+                       use_previous=useprevious)
 
 
 @cli.command()

--- a/boondoggle/cli.py
+++ b/boondoggle/cli.py
@@ -42,9 +42,9 @@ def cli(context, profile, region):
               help="Path to a cloudformation file.")
 @click.option('--outputs-from',
               help="Use another stack's outputs as inputs to this one.")
-@click.option('--useprevious', is_flag=True,
+@click.option('--use-previous-params', is_flag=True,
               help="Use existing stack's parameters if any are excluded from this call.")
-def ensure(context, name, params, url, file, outputs_from, useprevious):
+def ensure(context, name, params, url, file, outputs_from, use_previous_params):
     """Updates the stack with the given name to use
     the specified template. This creates the stack if
     necessary.
@@ -58,7 +58,7 @@ def ensure(context, name, params, url, file, outputs_from, useprevious):
     context.obj.ensure(name, template_parameters,
                        url=url, path=file,
                        outputs_from=outputs_from,
-                       use_previous=useprevious)
+                       use_previous=use_previous_params)
 
 
 @cli.command()

--- a/boondoggle/cli.py
+++ b/boondoggle/cli.py
@@ -42,7 +42,7 @@ def cli(context, profile, region):
               help="Path to a cloudformation file.")
 @click.option('--outputs-from',
               help="Use another stack's outputs as inputs to this one.")
-@click.option('--useprevious',
+@click.option('--useprevious', is_flag=True,
               help="Use existing stack's parameters if any are excluded from this call.")
 def ensure(context, name, params, url, file, outputs_from, useprevious):
     """Updates the stack with the given name to use

--- a/boondoggle/managers.py
+++ b/boondoggle/managers.py
@@ -54,9 +54,8 @@ class DeployManager(object):
             if status is None:
                 self.cf.create_stack(**args)
             else:
-                if use_previous == "True":
+                if use_previous:
                     args['parameters'] = self.fill_from_existing(args['parameters'], existing.parameters)
-                    print('params:', args['parameters'])
                 self.cf.update_stack(**args)
         except BotoServerError, ex:
             if ex.status == 403:
@@ -88,10 +87,8 @@ class DeployManager(object):
                 if newTuple[0] == oldParamObj.key:
                     found = True
                     retParams.append(newTuple)
-                    print('append new')
             if found == False:
                 retParams.append((oldParamObj.key, oldParamObj.value))
-                print('append old')
         return retParams
 
     def cancel_update(self, name):


### PR DESCRIPTION
Allow -useprevious flag which merges any parameters in the existing Cloud Formation stack that were not included in the ensure call
